### PR TITLE
fix: Sequence of Choices has leftover prettier-induced syntax error

### DIFF
--- a/plugins/plugin-client-offline/notebooks/playground.md
+++ b/plugins/plugin-client-offline/notebooks/playground.md
@@ -9,16 +9,6 @@ layout:
     maximized: true
 ---
 
-=== "Choice"
-    ```bash
-    ---
-    execute: now
-    maximize: true
-    outputOnly: true
-    ---
-    commentary --send guidebook-playground -f /kui/madwizard/playground/hello.md
-    ```
-
 === "Sequence of Choices"
     ```bash
     ---
@@ -27,7 +17,7 @@ layout:
     outputOnly: true
     ---
     commentary --send guidebook-playground -f /kui/madwizard/playground/two-choices.md
-    `
+    ```
 
 === "Multi-select"
     ```bash


### PR DESCRIPTION
This PR also removes the trivial single-choice tab. It is so trivial that it seems like there might be a bug -- not much happens. The Sequence of Choices is more interesting, and not much more complicated.