### PR TITLE
fix: small optimizations to page load

### DIFF
--- a/plugins/plugin-client-offline/src/index.tsx
+++ b/plugins/plugin-client-offline/src/index.tsx
@@ -43,7 +43,9 @@ export default function renderMain(props: KuiProps) {
       productName={productName}
       lightweightTables
       {...props}
-      commandLine={props.commandLine || autoplay.length === 0 ? [] : ["replay", "-r", ...autoplay]}
+      quietExecCommand={false}
+      loading={<div />}
+      commandLine={props.commandLine || autoplay.length === 0 ? [] : ["commentary", "--readonly", "-f", ...autoplay]}
     >
       <ContextWidgets>
         {/* widgets you want to appear flush left */}

--- a/plugins/plugin-client-offline/web/scss/components/Client/_index.scss
+++ b/plugins/plugin-client-offline/web/scss/components/Client/_index.scss
@@ -19,3 +19,10 @@
 
 /** Tweak the markdown headings UI a bit */
 @import "headings";
+
+@import "@kui-shell/plugin-client-common/web/scss/components/Terminal/mixins";
+@include Scrollback {
+  @include ProcessingBlock {
+    display: none;
+  }
+}


### PR DESCRIPTION
1. don't bother rendering ProcessingBlock; this also avoids the UI glitch where `commentary -f ...` is briefly shown
2. invoke `commentary` directly, rather than via `replay`